### PR TITLE
Fix config card layout overflow and DST maintenance window bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lmon - Lightweight Monitoring Service
 ![go](https://github.com/pilotso11/lmon/actions/workflows/go.yml/badge.svg)
 ![docker](https://github.com/pilotso11/lmon/actions/workflows/docker.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Coverage-88.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-87.9%25-brightgreen)
 
 A lightweight, extensible monitoring service written in Go. lmon monitors system resources, disk usage, and application health, providing a modern web UI and flexible configuration.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lmon - Lightweight Monitoring Service
 ![go](https://github.com/pilotso11/lmon/actions/workflows/go.yml/badge.svg)
 ![docker](https://github.com/pilotso11/lmon/actions/workflows/docker.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Coverage-87.9%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-88.1%25-brightgreen)
 
 A lightweight, extensible monitoring service written in Go. lmon monitors system resources, disk usage, and application health, providing a modern web UI and flexible configuration.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lmon - Lightweight Monitoring Service
 ![go](https://github.com/pilotso11/lmon/actions/workflows/go.yml/badge.svg)
 ![docker](https://github.com/pilotso11/lmon/actions/workflows/docker.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Coverage-88.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-88.1%25-brightgreen)
 
 A lightweight, extensible monitoring service written in Go. lmon monitors system resources, disk usage, and application health, providing a modern web UI and flexible configuration.
 

--- a/monitors/maintenance.go
+++ b/monitors/maintenance.go
@@ -14,6 +14,10 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 // IsInMaintenanceWindow returns true if the given time falls within an active
 // maintenance window defined by cfg. Returns false if cfg is nil, has an empty
 // Cron expression, or has an invalid cron expression.
+//
+// Cron expressions are evaluated in UTC to avoid issues with DST transitions.
+// During a spring-forward transition, local-time evaluation can skip triggers
+// that fall in the missing hour, causing maintenance windows to be missed.
 func IsInMaintenanceWindow(cfg *config.MaintenanceConfig, now time.Time) bool {
 	if cfg == nil || cfg.Cron == "" || cfg.Duration <= 0 {
 		return false
@@ -24,10 +28,14 @@ func IsInMaintenanceWindow(cfg *config.MaintenanceConfig, now time.Time) bool {
 	}
 	duration := time.Duration(cfg.Duration) * time.Second
 
+	// Evaluate in UTC to avoid DST gaps where schedule.Next() would skip
+	// triggers that fall in a non-existent local hour.
+	nowUTC := now.UTC()
+
 	// Find the most recent cron trigger at or before now.
 	// cron.Next(t) returns the first trigger strictly after t.
 	// So Next(now - duration) gives us the earliest trigger that could still
 	// have an active window covering now.
-	candidate := schedule.Next(now.Add(-duration))
-	return !candidate.After(now)
+	candidate := schedule.Next(nowUTC.Add(-duration))
+	return !candidate.After(nowUTC)
 }

--- a/monitors/maintenance.go
+++ b/monitors/maintenance.go
@@ -18,6 +18,9 @@ var cronParser = cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month 
 // Cron expressions are evaluated in UTC to avoid issues with DST transitions.
 // During a spring-forward transition, local-time evaluation can skip triggers
 // that fall in the missing hour, causing maintenance windows to be missed.
+// Maintenance cron expressions in configuration files and UI fields must
+// therefore be written in UTC; existing schedules that were specified in
+// local time should be converted to UTC to preserve their original behavior.
 func IsInMaintenanceWindow(cfg *config.MaintenanceConfig, now time.Time) bool {
 	if cfg == nil || cfg.Cron == "" || cfg.Duration <= 0 {
 		return false

--- a/monitors/maintenance_test.go
+++ b/monitors/maintenance_test.go
@@ -94,3 +94,55 @@ func TestIsInMaintenanceWindow_MidnightCrossing(t *testing.T) {
 	now := time.Date(2026, 3, 29, 0, 0, 30, 0, time.UTC) // 30s after midnight
 	assert.True(t, IsInMaintenanceWindow(cfg, now))
 }
+
+func TestIsInMaintenanceWindow_DSTSpringForward_InWindow(t *testing.T) {
+	// Simulate BST spring-forward: clocks go from 1:00 GMT to 2:00 BST.
+	// Cron fires at 1:30 UTC. During spring-forward in Europe/London,
+	// 1:30 local doesn't exist (skipped from 1:00 to 2:00).
+	// With UTC evaluation, the trigger should still fire correctly.
+	london, err := time.LoadLocation("Europe/London")
+	assert.NoError(t, err)
+
+	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
+	// 2026-03-29 is BST spring-forward day in UK.
+	// At 1:31 UTC (which is 2:31 BST local), the window should be active
+	// because the cron triggered at 1:30 UTC with 120s duration.
+	now := time.Date(2026, 3, 29, 1, 31, 0, 0, london)
+	assert.True(t, IsInMaintenanceWindow(cfg, now))
+}
+
+func TestIsInMaintenanceWindow_DSTSpringForward_OutsideWindow(t *testing.T) {
+	london, err := time.LoadLocation("Europe/London")
+	assert.NoError(t, err)
+
+	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
+	// At 1:33 UTC (2:33 BST), 3 minutes after trigger, outside the 120s window.
+	now := time.Date(2026, 3, 29, 1, 33, 0, 0, london)
+	assert.False(t, IsInMaintenanceWindow(cfg, now))
+}
+
+func TestIsInMaintenanceWindow_DSTFallBack_InWindow(t *testing.T) {
+	// Simulate BST fall-back: clocks go from 2:00 BST back to 1:00 GMT.
+	// The hour 1:00-2:00 occurs twice. Cron at 1:30 UTC should still work.
+	london, err := time.LoadLocation("Europe/London")
+	assert.NoError(t, err)
+
+	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
+	// 2026-10-25 is BST fall-back day in UK.
+	// At 1:31 UTC (which is 1:31 GMT after fall-back), window should be active.
+	now := time.Date(2026, 10, 25, 1, 31, 0, 0, london)
+	assert.True(t, IsInMaintenanceWindow(cfg, now))
+}
+
+func TestIsInMaintenanceWindow_LocalTimeConvertedToUTC(t *testing.T) {
+	// Verify that a time passed in a non-UTC timezone is correctly
+	// converted to UTC for evaluation.
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	assert.NoError(t, err)
+
+	// Cron fires at 0:00 UTC. Tokyo is UTC+9, so 9:00 JST = 0:00 UTC.
+	cfg := &config.MaintenanceConfig{Cron: "0 0 * * *", Duration: 120}
+	// 9:01 JST = 0:01 UTC, should be in the 120s window.
+	now := time.Date(2026, 3, 28, 9, 1, 0, 0, tokyo)
+	assert.True(t, IsInMaintenanceWindow(cfg, now))
+}

--- a/monitors/maintenance_test.go
+++ b/monitors/maintenance_test.go
@@ -97,27 +97,29 @@ func TestIsInMaintenanceWindow_MidnightCrossing(t *testing.T) {
 
 func TestIsInMaintenanceWindow_DSTSpringForward_InWindow(t *testing.T) {
 	// Simulate BST spring-forward: clocks go from 1:00 GMT to 2:00 BST.
-	// Cron fires at 1:30 UTC. During spring-forward in Europe/London,
-	// 1:30 local doesn't exist (skipped from 1:00 to 2:00).
-	// With UTC evaluation, the trigger should still fire correctly.
+	// Cron fires at 1:30 UTC. With UTC evaluation, the trigger fires correctly
+	// even though 1:30 local doesn't exist during spring-forward.
 	london, err := time.LoadLocation("Europe/London")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Skip("Europe/London timezone not available")
+	}
 
 	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
 	// 2026-03-29 is BST spring-forward day in UK.
-	// At 1:31 UTC (which is 2:31 BST local), the window should be active
-	// because the cron triggered at 1:30 UTC with 120s duration.
-	now := time.Date(2026, 3, 29, 1, 31, 0, 0, london)
+	// Construct in UTC to avoid non-existent local time, then convert to London.
+	now := time.Date(2026, 3, 29, 1, 31, 0, 0, time.UTC).In(london)
 	assert.True(t, IsInMaintenanceWindow(cfg, now))
 }
 
 func TestIsInMaintenanceWindow_DSTSpringForward_OutsideWindow(t *testing.T) {
 	london, err := time.LoadLocation("Europe/London")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Skip("Europe/London timezone not available")
+	}
 
 	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
 	// At 1:33 UTC (2:33 BST), 3 minutes after trigger, outside the 120s window.
-	now := time.Date(2026, 3, 29, 1, 33, 0, 0, london)
+	now := time.Date(2026, 3, 29, 1, 33, 0, 0, time.UTC).In(london)
 	assert.False(t, IsInMaintenanceWindow(cfg, now))
 }
 
@@ -125,12 +127,14 @@ func TestIsInMaintenanceWindow_DSTFallBack_InWindow(t *testing.T) {
 	// Simulate BST fall-back: clocks go from 2:00 BST back to 1:00 GMT.
 	// The hour 1:00-2:00 occurs twice. Cron at 1:30 UTC should still work.
 	london, err := time.LoadLocation("Europe/London")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Skip("Europe/London timezone not available")
+	}
 
 	cfg := &config.MaintenanceConfig{Cron: "30 1 * * *", Duration: 120}
 	// 2026-10-25 is BST fall-back day in UK.
-	// At 1:31 UTC (which is 1:31 GMT after fall-back), window should be active.
-	now := time.Date(2026, 10, 25, 1, 31, 0, 0, london)
+	// Construct in UTC to avoid ambiguous local time, then convert to London.
+	now := time.Date(2026, 10, 25, 1, 31, 0, 0, time.UTC).In(london)
 	assert.True(t, IsInMaintenanceWindow(cfg, now))
 }
 
@@ -138,7 +142,9 @@ func TestIsInMaintenanceWindow_LocalTimeConvertedToUTC(t *testing.T) {
 	// Verify that a time passed in a non-UTC timezone is correctly
 	// converted to UTC for evaluation.
 	tokyo, err := time.LoadLocation("Asia/Tokyo")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Skip("Asia/Tokyo timezone not available")
+	}
 
 	// Cron fires at 0:00 UTC. Tokyo is UTC+9, so 9:00 JST = 0:00 UTC.
 	cfg := &config.MaintenanceConfig{Cron: "0 0 * * *", Duration: 120}

--- a/uitest/edit_test.go
+++ b/uitest/edit_test.go
@@ -444,6 +444,125 @@ func TestAddDiskWithMaintenanceViaUI(t *testing.T) {
 	assert.Equal(t, "60", durVal.Value.String(), "Maintenance duration should be populated")
 }
 
+// TestAddHealthCheckWithMaintenanceLayout tests that adding a health check with a
+// maintenance window renders the maintenance badge on a separate line (in .config-item-maint)
+// rather than inline in the main flex row.
+func TestAddHealthCheckWithMaintenanceLayout(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	s, _ := web.StartTestServer(ctx, t, "")
+	s.Start(ctx)
+
+	browser := getBrowser(t)
+	defer closeBrowser(browser)
+	page, err := browser.Page(proto.TargetCreateTarget{URL: s.ServerUrl})
+	requireNoErrorWithScreenshot(t, page, err, "open page")
+	defer closePage(page)
+
+	// Navigate to config page
+	configLink, err := page.Element(`a.nav-link[href="/config"]`)
+	requireNoErrorWithScreenshot(t, page, err, "find config tab")
+	err = configLink.Click(proto.InputMouseButtonLeft, 1)
+	requireNoErrorWithScreenshot(t, page, err, "click config tab")
+
+	// Wait for monitor form
+	_, err = page.Timeout(1 * time.Second).Element(`#add-monitor-form`)
+	requireNoErrorWithScreenshot(t, page, err, "wait for add-monitor-form")
+
+	// Fill out health check form
+	nameEl, err := page.Element(`#monitor-name`)
+	requireNoErrorWithScreenshot(t, page, err, "find monitor-name input")
+	err = nameEl.Input("maint-layout-test")
+	requireNoErrorWithScreenshot(t, page, err, "input monitor-name")
+
+	urlEl, err := page.Element(`#monitor-target`)
+	requireNoErrorWithScreenshot(t, page, err, "find monitor-target input")
+	err = urlEl.Input("http://example.com/health")
+	requireNoErrorWithScreenshot(t, page, err, "input monitor-target")
+
+	// Fill maintenance fields
+	cronEl, err := page.Element(`#monitor-maint-cron`)
+	requireNoErrorWithScreenshot(t, page, err, "find maintenance cron input")
+	err = cronEl.Input("0 */4 * * *")
+	requireNoErrorWithScreenshot(t, page, err, "input maintenance cron")
+
+	durEl, err := page.Element(`#monitor-maint-duration`)
+	requireNoErrorWithScreenshot(t, page, err, "find maintenance duration input")
+	err = durEl.Input("120")
+	requireNoErrorWithScreenshot(t, page, err, "input maintenance duration")
+
+	// Submit
+	submitEl, err := page.Element(`#add-monitor-form button[type="submit"]`)
+	requireNoErrorWithScreenshot(t, page, err, "find submit button")
+	err = submitEl.Click(proto.InputMouseButtonLeft, 1)
+	requireNoErrorWithScreenshot(t, page, err, "click submit")
+
+	// Wait for reload
+	err = page.Timeout(2 * time.Second).Reload()
+	requireNoErrorWithScreenshot(t, page, err, "wait for reload")
+
+	// Verify the config item exists
+	assert.Eventually(t, func() bool {
+		items, err := page.Elements(`#health-config-items .config-item`)
+		if err != nil {
+			return false
+		}
+		for _, item := range items {
+			nameSpan, err := item.Element(`.config-item-name`)
+			if err != nil {
+				continue
+			}
+			nameText, err := nameSpan.Text()
+			if err != nil {
+				continue
+			}
+			if nameText == "maint-layout-test" {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 50*time.Millisecond, "wait for health check item in config list")
+
+	// Find the config item for our monitor
+	items, err := page.Elements(`#health-config-items .config-item`)
+	requireNoErrorWithScreenshot(t, page, err, "get health config items")
+
+	var found bool
+	for _, item := range items {
+		nameSpan, err := item.Element(`.config-item-name`)
+		if err != nil {
+			continue
+		}
+		nameText, err := nameSpan.Text()
+		if err != nil || nameText != "maint-layout-test" {
+			continue
+		}
+
+		// Verify the maintenance badge is in a .config-item-maint div (second line),
+		// not inline in the d-flex row
+		maintDiv, err := item.Element(`.config-item-maint`)
+		requireNoErrorWithScreenshot(t, page, err, "maintenance badge should be in .config-item-maint div")
+
+		maintText, err := maintDiv.Text()
+		requireNoErrorWithScreenshot(t, page, err, "get maintenance div text")
+		assert.Contains(t, maintText, "Maint:", "Maintenance badge should contain 'Maint:'")
+		assert.Contains(t, maintText, "0 */4 * * *", "Maintenance badge should contain cron expression")
+		assert.Contains(t, maintText, "120s", "Maintenance badge should contain duration")
+
+		// Verify the maintenance badge is NOT inside the d-flex row
+		flexRow, err := item.Element(`.d-flex`)
+		requireNoErrorWithScreenshot(t, page, err, "find flex row")
+		hasMaintInFlex, _, err := flexRow.Has(`.badge.bg-info`)
+		requireNoErrorWithScreenshot(t, page, err, "check for badge in flex row")
+		assert.False(t, hasMaintInFlex, "Maintenance badge should NOT be inside the flex row")
+
+		found = true
+		break
+	}
+	assert.True(t, found, "Should find the maint-layout-test config item")
+}
+
 // contains is a simple string contains helper for use in Eventually assertions.
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || strings.Contains(s, substr))

--- a/uitest/edit_test.go
+++ b/uitest/edit_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-rod/rod"
 	"github.com/go-rod/rod/lib/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"lmon/web"
 )
@@ -502,14 +504,15 @@ func TestAddHealthCheckWithMaintenanceLayout(t *testing.T) {
 	err = page.Timeout(2 * time.Second).Reload()
 	requireNoErrorWithScreenshot(t, page, err, "wait for reload")
 
-	// Verify the config item exists
+	// Verify the config item exists and find it
+	var item *rod.Element
 	assert.Eventually(t, func() bool {
 		items, err := page.Elements(`#health-config-items .config-item`)
 		if err != nil {
 			return false
 		}
-		for _, item := range items {
-			nameSpan, err := item.Element(`.config-item-name`)
+		for _, i := range items {
+			nameSpan, err := i.Element(`.config-item-name`)
 			if err != nil {
 				continue
 			}
@@ -518,49 +521,31 @@ func TestAddHealthCheckWithMaintenanceLayout(t *testing.T) {
 				continue
 			}
 			if nameText == "maint-layout-test" {
+				item = i
 				return true
 			}
 		}
 		return false
 	}, 2*time.Second, 50*time.Millisecond, "wait for health check item in config list")
+	require.NotNil(t, item, "Should find the maint-layout-test config item")
 
-	// Find the config item for our monitor
-	items, err := page.Elements(`#health-config-items .config-item`)
-	requireNoErrorWithScreenshot(t, page, err, "get health config items")
+	// Verify the maintenance badge is in a .config-item-maint div (second line),
+	// not inline in the d-flex row
+	maintDiv, err := item.Element(`.config-item-maint`)
+	requireNoErrorWithScreenshot(t, page, err, "maintenance badge should be in .config-item-maint div")
 
-	var found bool
-	for _, item := range items {
-		nameSpan, err := item.Element(`.config-item-name`)
-		if err != nil {
-			continue
-		}
-		nameText, err := nameSpan.Text()
-		if err != nil || nameText != "maint-layout-test" {
-			continue
-		}
+	maintText, err := maintDiv.Text()
+	requireNoErrorWithScreenshot(t, page, err, "get maintenance div text")
+	assert.Contains(t, maintText, "Maint:", "Maintenance badge should contain 'Maint:'")
+	assert.Contains(t, maintText, "0 */4 * * *", "Maintenance badge should contain cron expression")
+	assert.Contains(t, maintText, "120s", "Maintenance badge should contain duration")
 
-		// Verify the maintenance badge is in a .config-item-maint div (second line),
-		// not inline in the d-flex row
-		maintDiv, err := item.Element(`.config-item-maint`)
-		requireNoErrorWithScreenshot(t, page, err, "maintenance badge should be in .config-item-maint div")
-
-		maintText, err := maintDiv.Text()
-		requireNoErrorWithScreenshot(t, page, err, "get maintenance div text")
-		assert.Contains(t, maintText, "Maint:", "Maintenance badge should contain 'Maint:'")
-		assert.Contains(t, maintText, "0 */4 * * *", "Maintenance badge should contain cron expression")
-		assert.Contains(t, maintText, "120s", "Maintenance badge should contain duration")
-
-		// Verify the maintenance badge is NOT inside the d-flex row
-		flexRow, err := item.Element(`.d-flex`)
-		requireNoErrorWithScreenshot(t, page, err, "find flex row")
-		hasMaintInFlex, _, err := flexRow.Has(`.badge.bg-info`)
-		requireNoErrorWithScreenshot(t, page, err, "check for badge in flex row")
-		assert.False(t, hasMaintInFlex, "Maintenance badge should NOT be inside the flex row")
-
-		found = true
-		break
-	}
-	assert.True(t, found, "Should find the maint-layout-test config item")
+	// Verify the maintenance badge is NOT inside the d-flex row
+	flexRow, err := item.Element(`.d-flex`)
+	requireNoErrorWithScreenshot(t, page, err, "find flex row")
+	hasMaintInFlex, _, err := flexRow.Has(`.badge.bg-info`)
+	requireNoErrorWithScreenshot(t, page, err, "check for badge in flex row")
+	assert.False(t, hasMaintInFlex, "Maintenance badge should NOT be inside the flex row")
 }
 
 // contains is a simple string contains helper for use in Eventually assertions.

--- a/uitest/main_test.go
+++ b/uitest/main_test.go
@@ -47,14 +47,17 @@ func TestServerHealth(t *testing.T) {
 }
 
 func getBrowser(t *testing.T) *rod.Browser {
-	var browser *rod.Browser
-	if os.Getenv("CI") != "" {
-		u, err := launcher.New().Set("no-sandbox").Launch()
-		require.NoError(t, err, "rod launch")
-		browser = rod.New().ControlURL(u).MustConnect()
-	} else {
-		browser = rod.New().MustConnect()
+	l := launcher.New()
+	if bin := os.Getenv("ROD_BROWSER"); bin != "" {
+		l = l.Bin(bin)
 	}
+	if os.Getenv("CI") != "" {
+		l = l.Set("no-sandbox")
+	}
+	l = l.Headless(true)
+	u, err := l.Launch()
+	require.NoError(t, err, "rod launch")
+	browser := rod.New().ControlURL(u).MustConnect()
 	return browser
 }
 

--- a/web/static/css/lmon.css
+++ b/web/static/css/lmon.css
@@ -153,6 +153,10 @@
 .config-item:hover {
     background-color: #f8f9fa;
 }
+.config-item-maint {
+    margin-left: 44px;
+    margin-top: 4px;
+}
 .delete-btn {
     color: var(--bs-danger, #dc3545) !important;
     cursor: pointer;

--- a/web/static/css/lmon.css
+++ b/web/static/css/lmon.css
@@ -154,7 +154,7 @@
     background-color: #f8f9fa;
 }
 .config-item-maint {
-    margin-left: 44px;
+    margin-left: 44px; /* align under name: icon (24px) + item-icon me-2 margin (10px) + padding (10px) */
     margin-top: 4px;
 }
 .delete-btn {

--- a/web/templates/config-docker-list.html
+++ b/web/templates/config-docker-list.html
@@ -130,9 +130,6 @@
                 {{ if gt $docker.AlertThreshold 1 }}
                 <span class="me-2">Alert: {{ $docker.AlertThreshold }}</span>
                 {{ end }}
-                {{ if $docker.Maintenance.Cron }}
-                <span class="me-2 badge bg-info">Maint: {{ $docker.Maintenance.Cron }} ({{ $docker.Maintenance.Duration }}s)</span>
-                {{ end }}
                 <button
                     type="button"
                     class="edit-docker-btn ms-auto p-0 btn btn-link me-2"
@@ -162,6 +159,11 @@
                     <i class="bi bi-trash" aria-hidden="true"></i>
                 </button>
             </div>
+            {{ if $docker.Maintenance.Cron }}
+            <div class="config-item-maint">
+                <span class="badge bg-info">Maint: {{ $docker.Maintenance.Cron }} ({{ $docker.Maintenance.Duration }}s)</span>
+            </div>
+            {{ end }}
         </div>
         {{ end }} {{ else }}
         <div class="text-center text-muted">No Docker monitors configured.</div>

--- a/web/templates/config-health-list.html
+++ b/web/templates/config-health-list.html
@@ -258,9 +258,6 @@
                     >Restart: <code>{{ $health.RestartContainers }}</code></span
                 >
                 {{ end }}
-                {{ if $health.Maintenance.Cron }}
-                <span class="me-2 badge bg-info">Maint: {{ $health.Maintenance.Cron }} ({{ $health.Maintenance.Duration }}s)</span>
-                {{ end }}
                 <button
                     type="button"
                     class="edit-health-btn ms-auto p-0 btn btn-link me-2"
@@ -292,6 +289,11 @@
                     <i class="bi bi-trash" aria-hidden="true"></i>
                 </button>
             </div>
+            {{ if $health.Maintenance.Cron }}
+            <div class="config-item-maint">
+                <span class="badge bg-info">Maint: {{ $health.Maintenance.Cron }} ({{ $health.Maintenance.Duration }}s)</span>
+            </div>
+            {{ end }}
         </div>
         {{ end }} {{ else }}
         <div class="text-center text-muted">No health checks configured.</div>
@@ -320,9 +322,6 @@
                 <span class="me-2 config-item-alert"
                     >Alert: {{ $ping.AlertThreshold }}</span
                 >
-                {{ end }}
-                {{ if $ping.Maintenance.Cron }}
-                <span class="me-2 badge bg-info">Maint: {{ $ping.Maintenance.Cron }} ({{ $ping.Maintenance.Duration }}s)</span>
                 {{ end }}
                 <button
                     type="button"
@@ -354,6 +353,11 @@
                     <i class="bi bi-trash" aria-hidden="true"></i>
                 </button>
             </div>
+            {{ if $ping.Maintenance.Cron }}
+            <div class="config-item-maint">
+                <span class="badge bg-info">Maint: {{ $ping.Maintenance.Cron }} ({{ $ping.Maintenance.Duration }}s)</span>
+            </div>
+            {{ end }}
         </div>
         {{ end }} {{ else }}
         <div class="text-center text-muted">No ping monitors configured.</div>


### PR DESCRIPTION
## Summary
- **Config card layout**: Move maintenance window badges from the inline flex row to a second line below the monitor name, preventing horizontal overflow on cards with restart containers + maintenance windows
- **DST bug (fixes #62)**: Evaluate maintenance window cron expressions in UTC instead of local time, so triggers during DST spring-forward gaps are no longer skipped
- **Test infrastructure**: Update go-rod `getBrowser` to support `ROD_BROWSER` env var for Playwright-installed Chromium in devcontainers

## Test plan
- [x] New DST tests: spring-forward (BST), fall-back, and cross-timezone UTC conversion
- [x] New UI test: `TestAddHealthCheckWithMaintenanceLayout` verifies maintenance badge renders in `.config-item-maint` div, not inline in flex row
- [x] All existing unit tests pass
- [x] All existing UI tests pass with Playwright Chromium

**Note**: Cron expressions are now evaluated in UTC. Existing maintenance window configs written in local time will need adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)