### PR TITLE
ci: grant contents:write so coverage-badge push stops failing CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,12 @@
 name: Go
 
+# The coverage-badge step commits + pushes README.md to the PR branch;
+# the default GITHUB_TOKEN needs contents write access or "Push coverage
+# badge" fails with `git exit code 128` whenever the badge changes.
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     branches: [ main ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lmon - Lightweight Monitoring Service
 ![go](https://github.com/pilotso11/lmon/actions/workflows/go.yml/badge.svg)
 ![docker](https://github.com/pilotso11/lmon/actions/workflows/docker.yml/badge.svg)
-![Coverage](https://img.shields.io/badge/Coverage-88.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-88.6%25-brightgreen)
 
 A lightweight, extensible monitoring service written in Go. lmon monitors system resources, disk usage, and application health, providing a modern web UI and flexible configuration.
 


### PR DESCRIPTION
Root cause of lmon CI failures (e.g. #65): the `Push coverage badge` step fails with git 128 on PRs because the workflow has no `permissions:` block (read-only GITHUB_TOKEN). Build/tests/benchmarks pass. Identical fix to lazywritercache #19.